### PR TITLE
範例的離開群組給到 roomId

### DIFF
--- a/WebApplication/Controllers/LineBotGroupController.cs
+++ b/WebApplication/Controllers/LineBotGroupController.cs
@@ -39,7 +39,7 @@ namespace WebApplication.Controllers
                             if (item.source.type.ToLower() == "room")
                                 isRock.LineBot.Utility.LeaveRoom(item.source.roomId, ChannelAccessToken);
                             if (item.source.type.ToLower() == "group")
-                                isRock.LineBot.Utility.LeaveGroup(item.source.roomId, ChannelAccessToken);
+                                isRock.LineBot.Utility.LeaveGroup(item.source.groupId, ChannelAccessToken);
 
                             break;
                         }


### PR DESCRIPTION
跟著練習時發現，群組提供 roomId 不會有反應。